### PR TITLE
Making sure the reference line gets set only on successful PUT req

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -165,7 +165,6 @@
     "no-inline-comments": 0,
     "no-lonely-if": 1,
     "no-mixed-spaces-and-tabs": 1,
-    "no-multiple-empty-lines": [1, { "max": 1 }],
     "no-nested-ternary": 0,
     "no-new-object": 1,
     "no-spaced-func": 1,
@@ -222,7 +221,7 @@
     "react/jsx-boolean-value": 1,
     "react/jsx-no-duplicate-props": 1,
     "react/jsx-no-undef": 1,
-    
+
     "react/jsx-sort-prop-types": 1,
     "react/jsx-sort-props": 0,
     "react/jsx-uses-react": 1,

--- a/actions.jsx
+++ b/actions.jsx
@@ -70,14 +70,19 @@ export function setReferenceValueForIndicator(indicatorId, referenceValue) {
         'boundary_type': 3,
       }),
       xhrFields: {
-        withCredentials: true
+        withCredentials: true,
       },
       /* eslint-enable */
-      success: (data) => {
-        return data;
+      success: (data, textStatus, xhr) => {
+        if (xhr.status === 200) {
+          return data;
+        }
+        else {
+          dispatch(showError('Instellen referentiewaarde mislukt...', 'error'));
+        }
       },
       error: (error) => {
-        dispatch(showError(error.responseJSON.message, 'error'));
+        console.log(error.responseJSON);
       },
     });
     Promise
@@ -86,7 +91,7 @@ export function setReferenceValueForIndicator(indicatorId, referenceValue) {
         dispatch(setReferenceValue(indicatorId, referenceValue));
       })
       .catch((reason) => {
-        dispatch(showError(reason, 'error'));
+        dispatch(showError('Instellen referentiewaarde mislukt...', 'error'));
       });
   };
 }

--- a/components/PerformanceIndicator.jsx
+++ b/components/PerformanceIndicator.jsx
@@ -83,7 +83,6 @@ class PerformanceIndicator extends Component {
     }
 
     const lastDate = new Date(linedata[linedata.length - 1].time);
-    // const timeBack = d3.timeMonth.offset(lastDate, interval);
     const timeBack = d3.time.month.offset(lastDate, interval);
 
     const lastScore = linedata[linedata.length - 1].score;


### PR DESCRIPTION
Should fix https://trello.com/c/JG4LU4Mg/762-kpi-bug-reference-value-should-not-be-settable-when-put-fails-0-5
