### PR TITLE
Region is now set in a Redux action

### DIFF
--- a/actions.jsx
+++ b/actions.jsx
@@ -278,6 +278,9 @@ export function fetchRegions(type) {
       let regions = {};
       regions.results = regionResults;
       return dispatch(receiveRegions(regions));
+    }).then((result) => {
+      const currentRegion = result.regions.results.features[0];
+      return dispatch(setRegion(currentRegion));
     });
   };
 }

--- a/components/App.jsx
+++ b/components/App.jsx
@@ -1,7 +1,6 @@
 // @flow
 import config from '../config.jsx';
 const loadingIndicator = require('./loading.svg');
-const almereGeojson = require('../almere.json');
 import { connect } from 'react-redux';
 import React, { Component, PropTypes } from 'react';
 import { Button, ButtonGroup, Grid, Row, Col, Label, Modal } from 'react-bootstrap';
@@ -100,12 +99,11 @@ class App extends Component {
     this._notificationSystem = this.refs.notificationSystem;
     this.props.dispatch(fetchIndicatorsIfNeeded());
     this.props.dispatch(fetchRegionsIfNeeded());
-    this.props.dispatch(setRegion(almereGeojson));
-    // ^^ Not the right way to do this but needed for presentation purpose
     this.props.dispatch(fetchApplicationBootstrap());
   }
 
   componentWillReceiveProps(newProps) {
+
     if (newProps.indicators.errormessage) {
       this._addNotification(
         newProps.indicators.errormessage.message,


### PR DESCRIPTION
Instead of setting region to hardcoded Almere, now takes highest region to return from the API, and sets that one as the active region.
