### PR TITLE
Consistent axes

### DIFF
--- a/components/PerformanceIndicator.jsx
+++ b/components/PerformanceIndicator.jsx
@@ -73,6 +73,7 @@ class PerformanceIndicator extends Component {
   }
 
   render() {
+
     let linedata = this.props.indicator.series.map((item) => {
       const formattedDate = moment(item.date).format('DD-MM-YYYY');
       return { time: formattedDate, value: item.value, score: item.score };
@@ -131,10 +132,10 @@ class PerformanceIndicator extends Component {
           />
          <YAxis
            yAxisId='right'
-           orientation='right'
+           orientation='left'
            padding={{ bottom: 10 }}
          />
-,10
+
          <Tooltip />
          <Bar
             type='monotone'
@@ -208,8 +209,8 @@ class PerformanceIndicator extends Component {
           &nbsp;&nbsp;
         </div>
           <ul className='list-unstyled list-inline' style={{ cursor: 'pointer' }}>
-            <li><i className='fa fa-cog'
-                   onClick={this._handleCogClick}></i>
+            <li>
+              <i className='fa fa-cog' onClick={this._handleCogClick}></i>
             </li>
             {
               ['5Y', '3Y', '1Y'].map((range, i) => {

--- a/components/ReferenceLabel.jsx
+++ b/components/ReferenceLabel.jsx
@@ -9,7 +9,7 @@ class ReferenceLabel extends Component {
   render() {
     const { x, y, stroke, payload, referenceVal } = this.props;
     return (
-      <text fill={'red'} x={0} y={(y - 5)}>
+      <text fill={'red'} x={25} y={(y - 5)}>
         Referentiewaarde ({referenceVal})
       </text>
     );


### PR DESCRIPTION
Makes both Y axes appear on left side of the chart (for scores and values):

![screen shot 2016-10-21 at 11 51 52](https://cloud.githubusercontent.com/assets/7193/19594288/c39dca52-9784-11e6-8ced-8e7a28114c26.jpg)

Fixes https://trello.com/c/QeWP7EAS/915-kpi-layout-verspringt-bij-schakelen-tussen-waardes-score
